### PR TITLE
Update gitlab_http_check.yml

### DIFF
--- a/.gitlab/workflows/gitlab_http_check.yml
+++ b/.gitlab/workflows/gitlab_http_check.yml
@@ -8,6 +8,7 @@ http_check_job:
     DEFAULT_OUTPUT_FILE: "result.json"
   before_script:
     - pip install requests
+    - pip install cryptography
   script:
     - python scripts/http_check_runner.py "$TARGET_URLS" --output_file "$DEFAULT_OUTPUT_FILE"
     - echo "Python script finished. Results should be in $DEFAULT_OUTPUT_FILE"


### PR DESCRIPTION
Add step to install cryptography dependency

Hi, i"ve noticed that the gitlab worker missing a step to install the cryptography dependency

![image](https://github.com/user-attachments/assets/2daf9589-dab6-4791-b26f-9c3d8e1ce0ec)
